### PR TITLE
Ticker should emit Double timestamps instead of Void

### DIFF
--- a/Sources/Venice/Ticker/Ticker.swift
+++ b/Sources/Venice/Ticker/Ticker.swift
@@ -25,10 +25,10 @@
 import C7
 
 public final class Ticker {
-    private let internalChannel = Channel<Void>()
+    private let internalChannel = Channel<UInt64>()
     private var stopped: Bool = false
 
-    public var channel: ReceivingChannel<Void> {
+    public var channel: ReceivingChannel<UInt64> {
         return internalChannel.receivingChannel
     }
 
@@ -37,7 +37,7 @@ public final class Ticker {
             while true {
                 nap(for: period)
                 if self.stopped { break }
-                self.internalChannel.send(Void())
+                self.internalChannel.send(UInt64(now()))
             }
         }
     }

--- a/Sources/Venice/Ticker/Ticker.swift
+++ b/Sources/Venice/Ticker/Ticker.swift
@@ -25,10 +25,10 @@
 import C7
 
 public final class Ticker {
-    private let internalChannel = Channel<UInt64>()
+    private let internalChannel = Channel<Double>()
     private var stopped: Bool = false
 
-    public var channel: ReceivingChannel<UInt64> {
+    public var channel: ReceivingChannel<Double> {
         return internalChannel.receivingChannel
     }
 
@@ -37,7 +37,7 @@ public final class Ticker {
             while true {
                 nap(for: period)
                 if self.stopped { break }
-                self.internalChannel.send(UInt64(now()))
+                self.internalChannel.send(now())
             }
         }
     }

--- a/Tests/VeniceTests/TickerTests.swift
+++ b/Tests/VeniceTests/TickerTests.swift
@@ -15,9 +15,9 @@ class TickerTests : XCTestCase {
 	func testTickerResolution() {
 		let ticker = Ticker(period: 10.milliseconds)
 		co {
-			var last: UInt64 = 0
+			var last: Double = 0
 			for time in ticker.channel {
-				XCTAssertTrue(time - last >= UInt64(0))
+				XCTAssertTrue(time - last >= Double(0))
 				last = time
 			}
 		}

--- a/Tests/VeniceTests/TickerTests.swift
+++ b/Tests/VeniceTests/TickerTests.swift
@@ -11,6 +11,20 @@ class TickerTests : XCTestCase {
         ticker.stop()
         nap(for: 20.milliseconds)
     }
+
+	func testTickerResolution() {
+		let ticker = Ticker(period: 10.milliseconds)
+		co {
+			var last: UInt64 = 0
+			for time in ticker.channel {
+				XCTAssertTrue(time - last >= UInt64(0))
+				last = time
+			}
+		}
+		nap(for: 100.milliseconds)
+		ticker.stop()
+		nap(for: 20.milliseconds)
+	}
 }
 
 extension TickerTests {


### PR DESCRIPTION
Hi, 

Some examples the Venice Docs show that a Ticker emits timestamps on its channel (`for time in Ticker().channel { … }`). But in the current 0.12.0 Venice, a Ticker emits on `Channel<Void>`. I could not find a commit regarding this change.

As I think it’s nice to have, I’d like to re-add this : a Ticker will emit timestamp (based on C7.Time.now()) on its `Channel<UInt64>`.

Do you agree?